### PR TITLE
Python 3.12 compat fix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v2

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     long_description_content_type='text/markdown',
     package_data={'': ['easy_word_list']},
     include_package_data=True,
-    install_requires=['pyphen'],
+    install_requires=['pyphen', 'setuptools'],
     license='MIT',
     python_requires=">=3.6",
     classifiers=(


### PR DESCRIPTION
With Python 3.12 I get the following error.

```
File ~\AppData\Local\Programs\Python\Python312\Lib\site-packages\textstat\textstat.py:7
      4 from collections import Counter
      5 from typing import Union, List, Set
----> 7 import pkg_resources
      8 from functools import lru_cache
      9 from pyphen import Pyphen

ModuleNotFoundError: No module named 'pkg_resources'
```

I think this is due to the following change:
 - [PEP 632](https://peps.python.org/pep-0632/)
 - [gh-95299]https://docs.python.org/3/whatsnew/3.12.html#:~:text=%2C%20setuptools%2C-,pkg_resources,-%2C%20and%20easy_install%20will)

I have not tested the fix.