### PR TITLE
use cmudict for more accurate syllable counting in en_US

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -5,6 +5,7 @@ name = "pypi"
 
 [packages]
 Pyphen = "*"
+cmudict = "*"
 "repoze.lru" = "*"
 setuptools = "*"
 

--- a/README.md
+++ b/README.md
@@ -419,7 +419,9 @@ textstat.syllable_count(text)
 Returns the number of syllables present in the given text.
 
 Uses the Python module [Pyphen](https://github.com/Kozea/Pyphen)
-for syllable calculation.
+for syllable calculation in most languages, but defaults to 
+[cmudict](https://github.com/prosegrinder/python-cmudict) for
+en_US.
 
 #### Lexicon Count
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Pyphen
+cmudict
 setuptools

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     long_description_content_type='text/markdown',
     package_data={'': ['easy_word_list']},
     include_package_data=True,
-    install_requires=['pyphen', 'setuptools'],
+    install_requires=['pyphen', 'cmudict', 'setuptools'],
     license='MIT',
     python_requires=">=3.6",
     classifiers=(

--- a/test.py
+++ b/test.py
@@ -5,6 +5,7 @@
 """
 
 import textstat
+import pytest
 
 short_test = "Cool dogs wear da sunglasses."
 
@@ -250,11 +251,44 @@ def test_lexicon_count():
     assert count_punc == 376
 
 
-def test_syllable_count():
-    textstat.set_lang("en_US")
-    count = textstat.syllable_count(long_test)
+@pytest.mark.parametrize(
+    "lang,text,n_syllables,margin",
+    [
+        ("en_US", short_test, 7, 0),
+        ("en_US", punct_text, 74, 2),
+        ("en_US", "faeries", 2, 1),
+        ("en_US", "relived", 2, 0),
+        ("en_US", "couple", 2, 0),
+        ("en_US", "enriched", 2, 0),
+        ("en_US", "us", 1, 0),
+        ("en_US", "too", 1, 0),
+        ("en_US", "monopoly", 4, 0),
+        ("en_US", "him", 1, 0),
+        ("en_US", "he", 1, 0),
+        ("en_US", "without", 2, 0),
+        ("en_US", "creative", 3, 0),
+        ("en_US", "every", 3, 0),
+        ("en_US", "stimulating", 4, 0),
+        ("en_US", "life", 1, 0),
+        ("en_US", "cupboards", 2, 0),
+        ("en_US", "day's", 1, 0),
+        ("en_US", "forgotten", 3, 0),
+        ("en_US", "through", 1, 0),
+        ("en_US", "marriage", 2, 0),
+        ("en_US", "hello", 2, 0),
+        ("en_US", "the", 1, 0),
+        ("en_US", "sentences", 3, 0),
+        ("en_US", "songwriter", 3, 0),
+        ("en_US", "removing", 3, 0),
+        ("en_US", "interpersonal", 5, 0),
+    ]
+)
+def test_syllable_count(lang: str, text: str, n_syllables: int, margin: int):
+    textstat.set_lang(lang)
+    count = textstat.syllable_count(text)
+    diff = abs(count - n_syllables)
 
-    assert count == 519
+    assert diff <= margin
 
 
 def test_sentence_count():
@@ -282,7 +316,7 @@ def test_avg_syllables_per_word():
     textstat.set_lang("en_US")
     avg = textstat.avg_syllables_per_word(long_test)
 
-    assert avg == 1.4
+    assert avg == 1.5
 
 
 def test_avg_letter_per_word():
@@ -303,7 +337,7 @@ def test_flesch_reading_ease():
     textstat.set_lang("en_US")
     score = textstat.flesch_reading_ease(long_test)
 
-    assert score == 66.17
+    assert score == 57.71
 
     textstat.set_lang("de_DE")
     score = textstat.flesch_reading_ease(long_test)
@@ -340,21 +374,21 @@ def test_flesch_kincaid_grade():
     textstat.set_lang("en_US")
     score = textstat.flesch_kincaid_grade(long_test)
 
-    assert score == 9.5
+    assert score == 10.7
 
 
 def test_polysyllabcount():
     textstat.set_lang("en_US")
     count = textstat.polysyllabcount(long_test)
 
-    assert count == 32
+    assert count == 38
 
 
 def test_smog_index():
     textstat.set_lang("en_US")
     index = textstat.smog_index(long_test)
 
-    assert index == 11.0
+    assert index == 11.7
 
 
 def test_coleman_liau_index():
@@ -375,7 +409,7 @@ def test_linsear_write_formula():
     textstat.set_lang("en_US")
     result = textstat.linsear_write_formula(long_test)
 
-    assert result == 14.5
+    assert result == 15.25
 
     result = textstat.linsear_write_formula(empty_str)
 
@@ -386,7 +420,7 @@ def test_difficult_words():
     textstat.set_lang("en_US")
     result = textstat.difficult_words(long_test)
 
-    assert result == 49
+    assert result == 54
 
 
 def test_difficult_words_list():
@@ -425,7 +459,7 @@ def test_gunning_fog():
     textstat.set_lang("en_US")
     score = textstat.gunning_fog(long_test)
 
-    assert score == 10.7
+    assert score == 11.13
 
     # FOG-PL
     textstat.set_lang("pl_PL")
@@ -456,7 +490,7 @@ def test_text_standard():
     textstat.set_lang("en_US")
     standard = textstat.text_standard(long_test)
 
-    assert standard == "10th and 11th grade"
+    assert standard == "11th and 12th grade"
 
     standard = textstat.text_standard(short_test)
 
@@ -531,7 +565,7 @@ def test_dale_chall_readability_score_v2():
     textstat.set_lang("en_US")
     score = textstat.dale_chall_readability_score_v2(long_test)
 
-    assert score == 6.8
+    assert score == 7.01
 
 
 def test_fernandez_huerta():
@@ -625,7 +659,7 @@ def test_disabling_rounding():
 
     textstat.set_rounding(True)
 
-    assert index == 5.057207463630613
+    assert index == 5.172798861480075
 
 
 def test_changing_rounding_points():
@@ -636,7 +670,7 @@ def test_changing_rounding_points():
 
     textstat.set_rounding(True)
 
-    assert index == 5.05721
+    assert index == 5.1728
 
 
 def test_instanced_textstat_rounding():
@@ -649,11 +683,11 @@ def test_instanced_textstat_rounding():
 
     my_not_rounded_index = my_textstat.spache_readability(long_test)
 
-    assert my_not_rounded_index == 5.057207463630613
+    assert my_not_rounded_index == 5.172798861480075
 
     default_rounded_index = textstat.spache_readability(long_test)
 
-    assert default_rounded_index == 5.06
+    assert default_rounded_index == 5.17
 
 
 def test_mcalpine_eflaw():

--- a/textstat/textstat.py
+++ b/textstat/textstat.py
@@ -330,7 +330,7 @@ class textstatistics:
 
     @lru_cache(maxsize=128)
     def syllable_count(self, text: str, lang: Union[str, None] = None) -> int:
-        """Calculate syllable words in a text using cmudict with pyphen as a fallback.
+        """Calculate syllable words in a text using cmudict and pyphen.
 
         Parameters
         ----------
@@ -365,7 +365,8 @@ class textstatistics:
         count = 0
         for word in text.split():
             try:
-                count += len([None for p in self.cmu_dict[word][0] if p[-1].isdigit()])
+                cmu_phones = self.cmu_dict[word][0]
+                count += len([None for p in cmu_phones if p[-1].isdigit()])
             except (TypeError, IndexError):
                 count += len(self.pyphen.positions(word)) + 1
 

--- a/textstat/textstat.py
+++ b/textstat/textstat.py
@@ -366,7 +366,7 @@ class textstatistics:
         for word in text.split():
             try:
                 cmu_phones = self.cmu_dict[word][0]
-                count += len([None for p in cmu_phones if p[-1].isdigit()])
+                count += sum(1 for p in cmu_phones if p[-1].isdigit())
             except (TypeError, IndexError):
                 count += len(self.pyphen.positions(word)) + 1
 


### PR DESCRIPTION
# Change Summary
Currently, Pyphen is used for syllable counting in all languages. It is not very accurate for this task, and this affects a lot of the different metrics textstat supports.

In this PR I propose using cmudict for en_US because it is far more accurate than Pyphen. Being a dictionary it does have "holes", but using Pyphen as a backup when those are detected can give us the best of both worlds.

I also expanded the testing for syllable counting, specifically designing the test change to track the "true" and currently expected syllable counts separately.

# Related conversations from the repo:
#195 
https://github.com/textstat/textstat/issues/167#issuecomment-901070413

# Justification/Motivation
For deciding whether this was worth doing I used this notebook/script to check a few different words from #195 and the existing test texts (which I labeled myself based on my own personal pronunciation). I found that pyphen was off by an average of .183 syllables per word while the cmudict approach was off by an average of .017 syllables per word, 10x less. This is of course not scientific at all due to being my own pronunciations and so few words but I think it motivates the PR well regardless.

For the sake of completeness, results (error rate) were as follows:
pyphen: 0.183
syllables: 0.117
cmudict mean: 0.057
cmudict first: 0.017

```
syllable_words = {
    "couple": 2,
    "enriched": 2,
    "us": 1,
    "too": 1,
    "monopoly": 4,
    "him": 1,
    "he": 1,
    "without": 2,
    "creative": 3,
    "every": 3,
    "stimulating": 4,
    "our": 1.5,
    "life": 1,
    "cupboards": 2,
    "day's": 1,
    "forgotten": 3,
    "through": 1,
    "marriage": 2,
    "hello": 2,
    "faerie": 2,
    "relive": 2,
    "cool": 1,
    "dogs": 1,
    "wear": 1,
    "da": 1,
    "the": 1,
    "sunglasses": 3,
    "sentences": 3,
    "songwriter": 3,
    "removing": 3
}
from typing import Callable

import numpy as np


def test_func(func: Callable[[str], int]):
    preds = [func(word.lower()) for word in syllable_words.keys()]
    _diffs = [(word, pred - score) for pred, (word, score) in zip(preds, syllable_words.items()) if pred]
    words, diffs = zip(*_diffs)
    mean_ = np.mean(np.abs(diffs))
    print(f"Overall mean: {mean_}")
    print(f"Able to score {len(diffs)} of {len(syllable_words)} words")
    print(f"Failed to score: {[w for w in syllable_words.keys() if w not in words]}")
    print()
    for word, diff in _diffs:
        print(f"{word}: {diff}")
    return mean_
from pyphen import Pyphen
phen = Pyphen(lang="en_US")

def pyphen_get(word: str) -> int:
    pyphen_locs = len(phen.positions(word))
    return pyphen_locs + 1

test_func(pyphen_get)
import syllables

def syll_get(word: str) -> int:
    syll_count = syllables.estimate(word)
    return syll_count

test_func(syll_get)
import cmudict

cmu_dict = cmudict.dict()

def cmu_get_mean(word: str) -> int:
    cmu_phones = cmu_dict.get(word)
    if cmu_phones:
        return np.mean([len([p for p in phone if p[-1].isdigit()]) for phone in cmu_phones])
    return 0

test_func(cmu_get_mean)
def cmu_get_first(word: str) -> int:
    cmu_phones = cmu_dict.get(word)
    if cmu_phones:
        return len([p for p in cmu_phones[0] if p[-1].isdigit()])
    return 0

test_func(cmu_get_first)
```