### PR TITLE
Catch KeyError when checking word from cmudict

### DIFF
--- a/tests/backend/counts/test_count_syllables.py
+++ b/tests/backend/counts/test_count_syllables.py
@@ -46,3 +46,10 @@ def test_syllable_count(lang: str, text: str, n_syllables: int, margin: int):
     count = counts.count_syllables(text, lang)
     diff = abs(count - n_syllables)
     assert diff <= margin
+
+
+def test_count_syllables_with_unknown_word():
+    """Test that count_syllables still produces an output when counting
+    an unknown word.
+    """
+    assert counts.count_syllables("text_a", "en_US") == 2

--- a/textstat/backend/counts/_count_syllables.py
+++ b/textstat/backend/counts/_count_syllables.py
@@ -29,6 +29,6 @@ def count_syllables(text: str, lang: str) -> int:
         try:
             cmu_phones = cmu_dict[word][0]
             count += sum(1 for p in cmu_phones if p[-1].isdigit())
-        except (TypeError, IndexError):
+        except (TypeError, IndexError, KeyError):
             count += len(pyphen.positions(word)) + 1
     return count


### PR DESCRIPTION
This adds an additional KeyError catch when trying to get a word from cmudict as the latest release of python-cmudict removed the defaultdict.

- prosegrinder/python-cmudict#122
